### PR TITLE
Fixed already registered message

### DIFF
--- a/bot_command.py
+++ b/bot_command.py
@@ -20,8 +20,9 @@ def register_user(rpc, msg):
             bot_logger.logger.warning('Error during register !')
     else:
         bot_logger.logger.info('%s are already registered ' % msg.author.name)
+        balance = crypto.get_user_balance(rpc, msg.author.name)
         address = user_function.get_user_address(msg.author.name)
-        msg.reply(lang.message_already_registered % address + lang.message_footer)
+        msg.reply(lang.message_already_registered + lang.message_account_details % (msg.author.name, address, balance) + lang.message_footer)
 
 
 def balance_user(rpc, msg):

--- a/bot_command.py
+++ b/bot_command.py
@@ -22,7 +22,7 @@ def register_user(rpc, msg):
         bot_logger.logger.info('%s are already registered ' % msg.author.name)
         balance = crypto.get_user_balance(rpc, msg.author.name)
         address = user_function.get_user_address(msg.author.name)
-        msg.reply(lang.message_already_registered + lang.message_account_details % (msg.author.name, address, balance) + lang.message_footer)
+        msg.reply(lang.message_already_registered + lang.message_account_details % (msg.author.name, address, str(balance)) + lang.message_footer)
 
 
 def balance_user(rpc, msg):

--- a/lang.py
+++ b/lang.py
@@ -21,7 +21,7 @@ message_need_register = 'Hello %s! You need to register an account before you ca
                         '\n\nThe successful register message will contain your Dogecoin address to your tipping account.'
 message_invalid_amount = '**^[such ^error]**: ^The ^tip ^amount ^must ^be ^at ^least ^1 ^doge. ^[[help]](' + link_help + ')'
 message_balance_low_tip = '**^[such ^error]**: ^/u/%s\'s ^balance ^is ^too ^low ^for ^this ^tip ^[[help]](' + link_help + ')'
-message_already_registered = 'You are already registered! Here are your address: %s'
+message_already_registered = 'You are already registered! Here are your account details:'
 message_balance_low_withdraw = 'Hello %s! It seems your balance of **Ð%s** is too low for this withdraw amount of **Ð%s**.' \
                                '\n\n[Want to try again?](' + link_withdraw + ')'
 


### PR DESCRIPTION
The already registered message is supposed to show the entire table in "lang.message_account_details", not just an address.