### PR TITLE
Revised recipient "need to register" message

### DIFF
--- a/bot_command.py
+++ b/bot_command.py
@@ -83,13 +83,14 @@ def withdraw_user(rpc, msg):
         msg.reply(lang.message_need_register % msg.author.name + lang.message_footer)
 
 
-def tip_user(rpc, msg):
+def tip_user(rpc, reddit, msg):
     bot_logger.logger.info('An user mention detected ')
     split_message = msg.body.lower().strip().split()
     tip_index = split_message.index('+/u/sodogetiptest')
 
     if split_message[tip_index] == '+/u/sodogetiptest' and split_message[tip_index + 2] == 'doge':
         amount = split_message[tip_index + 1]
+        value_usd = utils.get_coin_value(amount)
 
         if utils.check_amount_valid(amount):
             parent_comment = msg.parent()
@@ -118,7 +119,6 @@ def tip_user(rpc, msg):
                                 '%s tip %s to %s' % (msg.author.name, str(amount), parent_comment.author.name))
                             # if user have 'verify' in this command he will have confirmation
                             if split_message.count('verify') or int(amount) >= 1000:
-                                value_usd = utils.get_coin_value(amount)
                                 msg.reply(lang.message_tip % (msg.author.name, parent_comment.author.name, str(amount), str(value_usd)))
                     else:
                         user_function.save_unregistered_tip(msg.author.name, parent_comment.author.name, amount)
@@ -126,10 +126,9 @@ def tip_user(rpc, msg):
                                                      amount,
                                                      "tip", False)
                         bot_logger.logger.info('user %s not registered' % parent_comment.author.name)
-                        msg.reply(
-                            '+/u/%s need [register](%s) before can be tipped (tip saved during 3 day)' % (
-                                parent_comment.author.name, lang.link_register) + lang.message_footer
-                        )
+                        msg.reply(lang.message_recipient_register % parent_comment.author.name)
+                        reddit.redditor(parent_comment.author.name).message(lang.message_recipient_need_register_title % str(amount), lang.message_recipient_need_register_message % (parent_comment.author.name, msg.author.name, str(amount), str(value_usd)))
+
             else:
                 msg.reply(lang.message_need_register % msg.author.name)
         else:

--- a/dogetipper.py
+++ b/dogetipper.py
@@ -79,7 +79,7 @@ class SoDogeTip():
 
                         elif split_message.count('+/u/sodogetiptest'):
                             self.mark_msg_read(msg)
-                            bot_command.tip_user(self.rpc_main, msg)
+                            bot_command.tip_user(self.rpc_main, self.reddit, msg)
 
                         else:
                             self.mark_msg_read(msg)

--- a/lang.py
+++ b/lang.py
@@ -51,3 +51,12 @@ message_footer = '\n\n*****' \
 message_help = 'To tip someone: \n\n Reply to their comment or post with: +/u/sodogetipbot 100 doge' \
                '\n\nReplace 100 with whatever amount you want to tip' \
                '\n\n*****'
+
+message_recipient_register = '**^[such ^error]**: ^/u/%s ^needs ^to ^[register](' + link_register + ') ^before ^receiving ^any ^tips ^(this ^tip ^has ^been ^saved ^for ^3 ^days) ^[[help]](' + link_help + ')'
+message_recipient_need_register_title = 'Someone sent you a Dogecoin tip of Ð%s, and you need to register to receive it!'
+message_recipient_need_register_message = 'Hello %s! You need to register an account before you can receive **%s\'s** Dogecoin tip of **Ð%s doge ($%s)**.' \
+                        '\n\nTo register an account:' \
+                        '\n\n1. [Click here](' + link_register + ') to send a pre-filled +register message' \
+                        '\n\n2. Click the "Send" button' \
+                        '\n\n3. Receive the successful register message' \
+                        '\n\nThe successful register message will contain your Dogecoin address to your tipping account.'


### PR DESCRIPTION
Changed comment made by bot from, "+/u/%s need [register](%s) before can be tipped (tip saved during 3 day)", to, "**^[such ^error]**: ^/u/%s ^needs ^to ^[register](' + link_register + ') ^before ^receiving ^any ^tips ^(this ^tip ^has ^been ^saved ^for ^3 ^days) ^[[help]](' + link_help + ')"

Sends a message to the unregistered recipient of a tip to notify that they received a tip and they'll need to register.

The text responsible for the messages are now in lang.py. They are: message_recipient_need_register_title, message_recipient_need_register_title, message_recipient_need_register_message